### PR TITLE
Fix description_file setup.cfg key

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,4 +14,4 @@ not_skip=__init__.py
 order_by_type = true
 
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Use underscore instead of hyphen for 'description_file'.  This fixes
the following warning:

    /usr/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead