### PR TITLE
Add `NTPRolloverException`, raised when system time is beyond NTPv3 r…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+version 0.X.X - 2022-XX-XX
+--------------------------
+- Add a new `NTPRolloverException` raised when system time is beyond NTPv3
+  rollover (https://en.wikipedia.org/wiki/Network_Time_Protocol#Timestamps)
+  Closes #18.
+
 version 0.4.0 - 2021-05-28
 --------------------------
 - flake8 conformance

--- a/ntplib.py
+++ b/ntplib.py
@@ -39,6 +39,12 @@ class NTPException(Exception):
     pass
 
 
+class NTPRolloverException(NTPException):
+    """Exception raised when the system time is beyond the NTPv3 rollover. """
+    # See https://en.wikipedia.org/wiki/Network_Time_Protocol#Timestamps
+    pass
+
+
 class NTP:
     """Helper class defining constants."""
 
@@ -392,6 +398,10 @@ def system_to_ntp_time(timestamp):
     Returns:
     corresponding NTP time
     """
+    if timestamp >= (NTP._NTP_EPOCH +
+                     datetime.timedelta(seconds=2 ** 32)).timestamp():
+        raise NTPRolloverException("Timestamp %s is beyond NTPv3 rollover" %
+                                   timestamp)
     return timestamp + NTP.NTP_DELTA
 
 

--- a/test_ntplib.py
+++ b/test_ntplib.py
@@ -1,6 +1,7 @@
 """Python NTP library tests."""
 
 
+import datetime
 import time
 import unittest
 
@@ -94,6 +95,22 @@ class TestNTPLib(unittest.TestCase):
         self.assertTrue(isinstance(ntplib.stratum_to_text(info.stratum), str))
         self.assertTrue(isinstance(ntplib.ref_id_to_text(info.ref_id,
                                                          info.stratum), str))
+
+    def test_rollover(self):
+        """ Test for rollover - see
+            https://en.wikipedia.org/wiki/Network_Time_Protocol#Timestamps.
+        """
+        ts = datetime.datetime(2022, 8, 5, 19, 8, 42).timestamp()
+        self.assertEqual(
+                ntplib.ntp_to_system_time(ntplib.system_to_ntp_time(ts)), ts)
+
+        ts = datetime.datetime(2036, 2, 7).timestamp()
+        self.assertEqual(
+                ntplib.ntp_to_system_time(ntplib.system_to_ntp_time(ts)), ts)
+
+        ts = datetime.datetime(2036, 2, 7, 12).timestamp()
+        self.assertRaises(ntplib.NTPRolloverException,
+                          ntplib.system_to_ntp_time, ts)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…ollover.

NTPv3 has a rollover in 2036 - see
https://en.wikipedia.org/wiki/Network_Time_Protocol#Timestamps.
Raise a specific exception if the system time is beyond that rollover,
to make it easier for users to understand what the problem is.

Closes #18.