### PR TITLE
Replace "ntp" service with port 123.

### DIFF
--- a/ntplib.py
+++ b/ntplib.py
@@ -283,7 +283,7 @@ class NTPClient(object):
     def __init__(self):
         """Constructor."""
 
-    def request(self, host, version=2, port="ntp", timeout=5, address_family=socket.AF_UNSPEC):  # pylint: disable=no-self-use,too-many-arguments
+    def request(self, host, version=2, port=123, timeout=5, address_family=socket.AF_UNSPEC):  # pylint: disable=no-self-use,too-many-arguments
         """Query a NTP server.
 
         Parameters:


### PR DESCRIPTION
Seems that some environments cannot resolve the "ntp" service, so hard-code port 123 instead.

Closes #32.